### PR TITLE
Fix docker image pull errors during installation

### DIFF
--- a/GEOGRAPHIC_BYPASS_GUIDE.md
+++ b/GEOGRAPHIC_BYPASS_GUIDE.md
@@ -1,0 +1,186 @@
+# راهنمای دور زدن محدودیت‌های جغرافیایی Docker Hub
+
+## مشکل
+Docker Hub به دلیل قوانین صادرات آمریکا، دسترسی از برخی کشورها (از جمله ایران) را مسدود کرده است. این خطا را دریافت می‌کنید:
+
+```
+Error response from daemon: pull access denied for prom/prometheus, repository does not exist or may require 'docker login': denied: <html><body><h1>403 Forbidden</h1>
+Since Docker is a US company, we must comply with US export control regulations...
+```
+
+## راه‌حل‌های موجود
+
+### 1. استفاده از اسکریپت خودکار (توصیه می‌شود)
+
+```bash
+# اجرای اسکریپت دور زدن محدودیت
+sudo ./install-geo-bypass.sh
+```
+
+این اسکریپت:
+- تنظیمات Docker را برای استفاده از آینه‌های ایرانی پیکربندی می‌کند
+- سعی می‌کند تصاویر را از منابع مختلف دانلود کند
+- گزینه‌های مختلف نصب را ارائه می‌دهد
+
+### 2. نصب دستی با تنظیمات Docker
+
+#### مرحله 1: تنظیم آینه‌های Docker
+
+```bash
+# ایجاد فایل تنظیمات Docker
+sudo mkdir -p /etc/docker
+
+sudo tee /etc/docker/daemon.json > /dev/null <<EOF
+{
+    "registry-mirrors": [
+        "https://docker.mirror.iranrepo.ir",
+        "https://docker.iranrepo.ir",
+        "https://registry.docker-cn.com",
+        "https://dockerhub.azk8s.cn",
+        "https://reg-mirror.qiniu.com"
+    ],
+    "insecure-registries": [
+        "docker.mirror.iranrepo.ir",
+        "docker.iranrepo.ir"
+    ]
+}
+EOF
+
+# راه‌اندازی مجدد Docker
+sudo systemctl restart docker
+```
+
+#### مرحله 2: دانلود تصاویر با منابع جایگزین
+
+```bash
+# دانلود تصاویر اصلی
+docker pull mysql:8.3
+docker pull redis:7-alpine
+docker pull nginx:alpine
+
+# دانلود تصاویر مانیتورینگ از منابع جایگزین
+docker pull quay.io/prometheus/prometheus:latest
+docker pull quay.io/grafana/grafana:latest
+
+# برچسب‌گذاری تصاویر جایگزین
+docker tag quay.io/prometheus/prometheus:latest prom/prometheus:latest
+docker tag quay.io/grafana/grafana:latest grafana/grafana:latest
+```
+
+#### مرحله 3: نصب با فایل‌های جایگزین
+
+**گزینه A: نصب کامل با مانیتورینگ**
+```bash
+docker-compose -f docker-compose-alternative.yml up -d
+```
+
+**گزینه B: نصب حداقلی بدون مانیتورینگ**
+```bash
+docker-compose -f docker-compose-minimal.yml up -d
+```
+
+### 3. استفاده از VPN یا پروکسی
+
+اگر روش‌های بالا کار نکرد، می‌توانید از VPN استفاده کنید:
+
+```bash
+# تنظیم پروکسی برای Docker (در صورت داشتن VPN)
+export HTTP_PROXY=http://your-proxy:port
+export HTTPS_PROXY=http://your-proxy:port
+export NO_PROXY=localhost,127.0.0.1
+
+# سپس اجرای نصب عادی
+docker-compose up -d
+```
+
+### 4. نصب بدون Docker (پیشرفته)
+
+اگر Docker اصلاً کار نمی‌کند، می‌توانید سرویس‌ها را مستقیماً نصب کنید:
+
+#### نصب MySQL
+```bash
+sudo apt update
+sudo apt install mysql-server-8.0
+sudo mysql_secure_installation
+```
+
+#### نصب Redis
+```bash
+sudo apt install redis-server
+sudo systemctl enable redis-server
+sudo systemctl start redis-server
+```
+
+#### نصب Python و وابستگی‌ها
+```bash
+sudo apt install python3 python3-pip python3-venv
+cd app
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## بررسی وضعیت نصب
+
+```bash
+# بررسی وضعیت کانتینرها
+docker ps
+
+# بررسی لاگ‌ها
+docker-compose logs
+
+# تست API
+curl http://localhost:8000/health
+```
+
+## دسترسی به سرویس‌ها
+
+- **API**: http://localhost:8000
+- **Bot**: در پس‌زمینه اجرا می‌شود
+- **Prometheus** (در صورت نصب): http://localhost:9090
+- **Grafana** (در صورت نصب): http://localhost:3000 (admin/admin)
+
+## عیب‌یابی
+
+### مشکل: تصاویر دانلود نمی‌شوند
+```bash
+# پاک کردن کش Docker
+docker system prune -a
+
+# تلاش مجدد با آینه‌های مختلف
+docker pull --platform linux/amd64 mysql:8.3
+```
+
+### مشکل: کانتینرها شروع نمی‌شوند
+```bash
+# بررسی لاگ‌ها
+docker-compose logs [service_name]
+
+# بررسی پورت‌های استفاده شده
+sudo netstat -tulpn | grep :3306
+sudo netstat -tulpn | grep :6379
+```
+
+### مشکل: دسترسی به دیتابیس
+```bash
+# اتصال به MySQL
+docker exec -it vpn_bot_mysql mysql -u root -p
+
+# اتصال به Redis
+docker exec -it vpn_bot_redis redis-cli
+```
+
+## نکات مهم
+
+1. **امنیت**: پس از نصب، رمزهای عبور پیش‌فرض را تغییر دهید
+2. **پشتیبان‌گیری**: از دیتابیس و تنظیمات پشتیبان تهیه کنید
+3. **به‌روزرسانی**: تصاویر Docker را به‌طور منظم به‌روزرسانی کنید
+4. **مانیتورینگ**: در صورت نیاز، سرویس‌های مانیتورینگ را فعال کنید
+
+## پشتیبانی
+
+در صورت بروز مشکل:
+1. لاگ‌های سیستم را بررسی کنید
+2. وضعیت سرویس‌ها را چک کنید
+3. از اسکریپت‌های جایگزین استفاده کنید
+4. در صورت نیاز، نصب دستی را امتحان کنید

--- a/docker-compose-alternative.yml
+++ b/docker-compose-alternative.yml
@@ -1,0 +1,166 @@
+version: '3.9'
+
+services:
+  db:
+    image: mysql:8.3
+    container_name: vpn_bot_mysql
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-vpn_bot}
+      MYSQL_USER: ${MYSQL_USER:-vpn_user}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-vpn_pass}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
+    command: ["--default-authentication-plugin=mysql_native_password", "--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci", "--innodb-buffer-pool-size=256M"]
+    volumes:
+      - db_data:/var/lib/mysql
+      - ./scripts/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -u$${MYSQL_USER} -p$${MYSQL_PASSWORD} || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+    networks:
+      - vpn_bot_network
+
+  redis:
+    image: redis:7-alpine
+    container_name: vpn_bot_redis
+    command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru
+    volumes:
+      - redis_data:/data
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - vpn_bot_network
+
+  api:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+    container_name: vpn_bot_api
+    env_file:
+      - ./.env
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+      - REDIS_URL=redis://redis:6379/0
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - "8000:8000"
+    command: uvicorn api.main:app --host 0.0.0.0 --port 8000 --workers 2 --proxy-headers
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: unless-stopped
+    networks:
+      - vpn_bot_network
+
+  bot:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+    container_name: vpn_bot_worker
+    env_file:
+      - ./.env
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+      - REDIS_URL=redis://redis:6379/0
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    command: python -m bot.main
+    healthcheck:
+      test: ["CMD", "python", "-c", "import requests; requests.get('https://api.telegram.org/bot${BOT_TOKEN}/getMe')"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped
+    networks:
+      - vpn_bot_network
+
+  nginx:
+    image: nginx:alpine
+    container_name: vpn_bot_nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/ssl:/etc/nginx/ssl:ro
+      - nginx_logs:/var/log/nginx
+    depends_on:
+      - api
+    restart: unless-stopped
+    networks:
+      - vpn_bot_network
+
+  # Alternative monitoring setup - using local builds or different registries
+  prometheus:
+    image: quay.io/prometheus/prometheus:latest
+    container_name: vpn_bot_prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--storage.tsdb.retention.time=200h'
+      - '--web.enable-lifecycle'
+    restart: unless-stopped
+    networks:
+      - vpn_bot_network
+
+  grafana:
+    image: quay.io/grafana/grafana:latest
+    container_name: vpn_bot_grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./monitoring/grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./monitoring/grafana/datasources:/etc/grafana/provisioning/datasources:ro
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+    networks:
+      - vpn_bot_network
+
+volumes:
+  db_data:
+    driver: local
+  redis_data:
+    driver: local
+  nginx_logs:
+    driver: local
+  prometheus_data:
+    driver: local
+  grafana_data:
+    driver: local
+
+networks:
+  vpn_bot_network:
+    driver: bridge

--- a/docker-compose-minimal.yml
+++ b/docker-compose-minimal.yml
@@ -1,0 +1,125 @@
+version: '3.9'
+
+services:
+  db:
+    image: mysql:8.3
+    container_name: vpn_bot_mysql
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-vpn_bot}
+      MYSQL_USER: ${MYSQL_USER:-vpn_user}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-vpn_pass}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
+    command: ["--default-authentication-plugin=mysql_native_password", "--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci", "--innodb-buffer-pool-size=256M"]
+    volumes:
+      - db_data:/var/lib/mysql
+      - ./scripts/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -u$${MYSQL_USER} -p$${MYSQL_PASSWORD} || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+    networks:
+      - vpn_bot_network
+
+  redis:
+    image: redis:7-alpine
+    container_name: vpn_bot_redis
+    command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru
+    volumes:
+      - redis_data:/data
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - vpn_bot_network
+
+  api:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+    container_name: vpn_bot_api
+    env_file:
+      - ./.env
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+      - REDIS_URL=redis://redis:6379/0
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - "8000:8000"
+    command: uvicorn api.main:app --host 0.0.0.0 --port 8000 --workers 2 --proxy-headers
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: unless-stopped
+    networks:
+      - vpn_bot_network
+
+  bot:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+    container_name: vpn_bot_worker
+    env_file:
+      - ./.env
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+      - REDIS_URL=redis://redis:6379/0
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    command: python -m bot.main
+    healthcheck:
+      test: ["CMD", "python", "-c", "import requests; requests.get('https://api.telegram.org/bot${BOT_TOKEN}/getMe')"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped
+    networks:
+      - vpn_bot_network
+
+  nginx:
+    image: nginx:alpine
+    container_name: vpn_bot_nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/ssl:/etc/nginx/ssl:ro
+      - nginx_logs:/var/log/nginx
+    depends_on:
+      - api
+    restart: unless-stopped
+    networks:
+      - vpn_bot_network
+
+volumes:
+  db_data:
+    driver: local
+  redis_data:
+    driver: local
+  nginx_logs:
+    driver: local
+
+networks:
+  vpn_bot_network:
+    driver: bridge

--- a/install-geo-bypass.sh
+++ b/install-geo-bypass.sh
@@ -1,0 +1,208 @@
+#!/bin/bash
+
+# VPN Telegram Bot - Geographic Bypass Installer
+# نصب کننده ربات تلگرام VPN با دور زدن محدودیت‌های جغرافیایی
+# Author: VPN Bot Team
+# Version: 1.0.0
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+PURPLE='\033[0;35m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# Banner
+print_banner() {
+    echo -e "${CYAN}"
+    echo "╔══════════════════════════════════════════════════════════════╗"
+    echo "║              VPN Telegram Bot - Geo Bypass                  ║"
+    echo "║         نصب کننده ربات تلگرام VPN - دور زدن محدودیت        ║"
+    echo "║                                                              ║"
+    echo "║  Version: 1.0.0                                              ║"
+    echo "║  Author: VPN Bot Team                                        ║"
+    echo "╚══════════════════════════════════════════════════════════════╝"
+    echo -e "${NC}"
+}
+
+# Logging functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check if running as root
+check_root() {
+    if [[ $EUID -ne 0 ]]; then
+        log_error "This script must be run as root"
+        exit 1
+    fi
+}
+
+# Configure Docker to use alternative registries
+configure_docker_registries() {
+    log_info "Configuring Docker to use alternative registries..."
+    
+    # Create or update Docker daemon configuration
+    mkdir -p /etc/docker
+    
+    cat > /etc/docker/daemon.json << EOF
+{
+    "registry-mirrors": [
+        "https://docker.mirror.iranrepo.ir",
+        "https://docker.iranrepo.ir",
+        "https://registry.docker-cn.com",
+        "https://dockerhub.azk8s.cn",
+        "https://reg-mirror.qiniu.com"
+    ],
+    "insecure-registries": [
+        "docker.mirror.iranrepo.ir",
+        "docker.iranrepo.ir"
+    ]
+}
+EOF
+
+    log_success "Docker registry configuration updated"
+}
+
+# Restart Docker service
+restart_docker() {
+    log_info "Restarting Docker service..."
+    systemctl restart docker
+    sleep 5
+    log_success "Docker service restarted"
+}
+
+# Try to pull images with different strategies
+pull_images_with_fallback() {
+    log_info "Attempting to pull Docker images with fallback strategies..."
+    
+    # List of images to pull
+    declare -A images=(
+        ["mysql:8.3"]="mysql:8.3"
+        ["redis:7-alpine"]="redis:7-alpine"
+        ["nginx:alpine"]="nginx:alpine"
+        ["prom/prometheus:latest"]="quay.io/prometheus/prometheus:latest"
+        ["grafana/grafana:latest"]="quay.io/grafana/grafana:latest"
+    )
+    
+    for original_image in "${!images[@]}"; do
+        alternative_image="${images[$original_image]}"
+        
+        log_info "Trying to pull: $original_image"
+        
+        # Try original image first
+        if docker pull "$original_image" 2>/dev/null; then
+            log_success "Successfully pulled: $original_image"
+            continue
+        fi
+        
+        # Try alternative registry
+        log_warning "Failed to pull $original_image, trying alternative: $alternative_image"
+        if docker pull "$alternative_image" 2>/dev/null; then
+            log_success "Successfully pulled alternative: $alternative_image"
+            # Tag the alternative image with the original name
+            docker tag "$alternative_image" "$original_image"
+        else
+            log_error "Failed to pull both $original_image and $alternative_image"
+        fi
+    done
+}
+
+# Install without monitoring (minimal setup)
+install_minimal() {
+    log_info "Installing minimal setup without monitoring components..."
+    
+    if [[ -f "docker-compose-minimal.yml" ]]; then
+        docker-compose -f docker-compose-minimal.yml up -d
+        log_success "Minimal setup completed successfully"
+    else
+        log_error "docker-compose-minimal.yml not found"
+        exit 1
+    fi
+}
+
+# Install with alternative monitoring
+install_with_alternative_monitoring() {
+    log_info "Installing with alternative monitoring setup..."
+    
+    if [[ -f "docker-compose-alternative.yml" ]]; then
+        docker-compose -f docker-compose-alternative.yml up -d
+        log_success "Alternative setup with monitoring completed successfully"
+    else
+        log_error "docker-compose-alternative.yml not found"
+        exit 1
+    fi
+}
+
+# Main installation function
+main() {
+    print_banner
+    
+    log_info "Starting VPN Bot installation with geographic bypass..."
+    
+    # Check if running as root
+    check_root
+    
+    # Configure Docker registries
+    configure_docker_registries
+    
+    # Restart Docker
+    restart_docker
+    
+    # Try to pull images
+    pull_images_with_fallback
+    
+    # Ask user for installation type
+    echo -e "${YELLOW}Choose installation type:${NC}"
+    echo "1) Minimal setup (without monitoring)"
+    echo "2) Full setup with alternative monitoring"
+    echo "3) Exit"
+    
+    read -p "Enter your choice (1-3): " choice
+    
+    case $choice in
+        1)
+            install_minimal
+            ;;
+        2)
+            install_with_alternative_monitoring
+            ;;
+        3)
+            log_info "Installation cancelled by user"
+            exit 0
+            ;;
+        *)
+            log_error "Invalid choice"
+            exit 1
+            ;;
+    esac
+    
+    log_success "Installation completed successfully!"
+    log_info "You can now access your VPN Bot at:"
+    log_info "- API: http://localhost:8000"
+    log_info "- Bot: Running in background"
+    
+    if [[ $choice -eq 2 ]]; then
+        log_info "- Prometheus: http://localhost:9090"
+        log_info "- Grafana: http://localhost:3000 (admin/admin)"
+    fi
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
Add multiple strategies to bypass Docker Hub geographic restrictions for image pulling.

Users in certain regions (e.g., Iran) face '403 Forbidden' errors when pulling images from Docker Hub due to export control regulations. This PR provides an automated script, alternative Docker Compose configurations (using different registries or a minimal setup), and a comprehensive guide to resolve these access issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-ebc7c572-0fae-4dab-b5b2-27e7acb951c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ebc7c572-0fae-4dab-b5b2-27e7acb951c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

