### PR TITLE
Resolve python package dependency conflicts

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -6,13 +6,13 @@ asyncpg==0.29.0
 aiomysql==0.2.0
 PyMySQL==1.1.1
 alembic==1.13.1
-pydantic==2.10.3
-pydantic-settings==2.7.0
+pydantic>=2.5.0,<2.11.0
+pydantic-settings>=2.0.0,<3.0.0
 python-dotenv==1.0.1
 httpx==0.27.0
 qrcode==7.4.2
-Pillow==10.3.0
+Pillow>=10.4.0
 passlib[bcrypt]==1.7.4
 python-multipart==0.0.9
-psycopg-binary==3.1.19
+psycopg-binary>=3.2.0
 aiosqlite==0.20.0


### PR DESCRIPTION
Update `pydantic`, `pydantic-settings`, `Pillow`, and `psycopg-binary` versions to resolve dependency conflicts during installation.

The previous versions of these packages caused `ResolutionImpossible` errors due to incompatibilities between `pydantic`, `aiogram`, and `fastapi`, as well as `Pillow` with Python 3.13, and an outdated `psycopg-binary` version.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb7765f6-89ea-4110-b320-1f3e29d9f11f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eb7765f6-89ea-4110-b320-1f3e29d9f11f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

