### PR TITLE
Change vpn bot api port

### DIFF
--- a/docker-compose-alternative.yml
+++ b/docker-compose-alternative.yml
@@ -58,7 +58,7 @@ services:
       redis:
         condition: service_healthy
     ports:
-      - "8000:8000"
+      - "8001:8000"
     command: uvicorn api.main:app --host 0.0.0.0 --port 8000 --workers 2 --proxy-headers
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]

--- a/docker-compose-minimal.yml
+++ b/docker-compose-minimal.yml
@@ -58,7 +58,7 @@ services:
       redis:
         condition: service_healthy
     ports:
-      - "8000:8000"
+      - "8001:8000"
     command: uvicorn api.main:app --host 0.0.0.0 --port 8000 --workers 2 --proxy-headers
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       redis:
         condition: service_healthy
     ports:
-      - "8000:8000"
+      - "8001:8000"
     command: uvicorn api.main:app --host 0.0.0.0 --port 8000 --workers 2 --proxy-headers
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]


### PR DESCRIPTION
Change the host port mapping for the API service to resolve a "port 8000 already in use" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7e7b87e-98d4-4cae-8370-5f3c0a07b63b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e7e7b87e-98d4-4cae-8370-5f3c0a07b63b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

