### PR TITLE
Debug docker compose volume error

### DIFF
--- a/app/models/advanced_reseller.py
+++ b/app/models/advanced_reseller.py
@@ -180,7 +180,7 @@ class ResellerActivity(Base):
     service_id: Mapped[Optional[int]] = mapped_column(ForeignKey("service.id"), nullable=True)
     
     # Metadata
-    metadata: Mapped[Optional[str]] = mapped_column(JSON, nullable=True)
+    payment_metadata: Mapped[Optional[str]] = mapped_column(JSON, nullable=True)
     
     # Date
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/app/models/crm.py
+++ b/app/models/crm.py
@@ -86,7 +86,7 @@ class UserActivity(Base):
     
     # Activity details
     description: Mapped[str] = mapped_column(String(512))
-    metadata: Mapped[Optional[str]] = mapped_column(JSON, nullable=True)  # Additional context
+    activity_metadata: Mapped[Optional[str]] = mapped_column(JSON, nullable=True)  # Additional context
     
     # Context
     session_id: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)


### PR DESCRIPTION
Rename `metadata` attributes in SQLAlchemy models to avoid conflict with reserved keywords.

The `metadata` attribute name is reserved in SQLAlchemy's Declarative API, causing `InvalidRequestError` during application startup. Renaming these attributes resolves the conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-ecd5250b-f9f4-40b0-869f-965d3b3d5f99">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ecd5250b-f9f4-40b0-869f-965d3b3d5f99">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

