### PR TITLE
Fix docker compose container config error

### DIFF
--- a/.env
+++ b/.env
@@ -8,7 +8,7 @@ LOG_LEVEL=INFO
 TZ=UTC
 
 # Database
-DATABASE_URL=postgresql+asyncpg://vpn_user:vpn_pass@db:5432/vpn_bot
+DATABASE_URL=mysql+aiomysql://vpn_user:vpn_pass@db:3306/vpn_bot
 
 # Settings
 SALES_ENABLED=true

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -9,7 +9,8 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
-    libpq-dev \
+    default-libmysqlclient-dev \
+    pkg-config \
     libjpeg62-turbo-dev \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Align database configuration to MySQL in `.env` and `Dockerfile` to resolve `KeyError: 'ContainerConfig'`.

The `KeyError: 'ContainerConfig'` was caused by a mismatch where the `.env` file specified a PostgreSQL database URL while the `docker-compose.yml` was configured for MySQL, and the Dockerfile was installing PostgreSQL development libraries. This PR updates the `.env` to use a MySQL URL and the Dockerfile to install MySQL development libraries, ensuring consistency across the application's database setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc240a15-1e5b-4ded-b3a5-4ab69757caab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cc240a15-1e5b-4ded-b3a5-4ab69757caab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

