### PR TITLE
Fix undefined numeric type in message analytics

### DIFF
--- a/app/models/scheduled_messages.py
+++ b/app/models/scheduled_messages.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from typing import Optional
 from enum import Enum
 
-from sqlalchemy import String, Integer, ForeignKey, Boolean, DateTime, Text, JSON, Enum as SQLEnum
+from sqlalchemy import String, Integer, ForeignKey, Boolean, DateTime, Text, JSON, Enum as SQLEnum, Numeric
 from sqlalchemy.orm import Mapped, mapped_column
 
 from .base import Base


### PR DESCRIPTION
Add `Numeric` to `sqlalchemy` import to resolve `NameError` when defining `MessageAnalytics` columns.

---
<a href="https://cursor.com/background-agent?bcId=bc-8cd30da8-331b-454a-94b5-56fe21c2cdac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8cd30da8-331b-454a-94b5-56fe21c2cdac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

